### PR TITLE
Add load_now_from_bytes

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -112,7 +112,7 @@ impl AnimatedImageLoader {
     /// ```
     /// # use vleue_kinetoscope::AnimatedImageLoader;
     /// # let mut app = bevy::prelude::App::new();
-    /// # app = app.add_plugins(bevy::prelude::AssetPlugin::default());
+    /// # app.add_plugins(bevy::prelude::AssetPlugin::default());
     /// let bytes = include_bytes!("../assets/cube.gif");
     /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", &mut app).unwrap();
     /// ```

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -112,6 +112,7 @@ impl AnimatedImageLoader {
     /// ```
     /// # use vleue_kinetoscope::AnimatedImageLoader;
     /// # let mut app = bevy::prelude::App::new();
+    /// # app = app.add_plugins(bevy::prelude::AssetPlugin::default());
     /// let bytes = include_bytes!("../assets/cube.gif");
     /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", &mut app).unwrap();
     /// ```

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -110,9 +110,10 @@ impl AnimatedImageLoader {
     /// Use `included_bytes!` macro to load the bytes.
     /// # Example
     /// ```
-    /// # let mut app = App::new();
-    /// let bytes = include_bytes!("../assets/foo.gif");
-    /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "gif", app).unwrap()
+    /// # use vleue_kinetoscope::AnimatedImageLoader;
+    /// # let mut app = bevy::prelude::App::new();
+    /// let bytes = include_bytes!("../assets/cube.gif");
+    /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", app).unwrap();
     /// ```
     pub fn load_now_from_bytes(
         bytes: &[u8],

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -107,7 +107,8 @@ impl AnimatedImageLoader {
 
     /// For gif that need to be loaded immediately, during app setup.
     /// This can be useful if the gif is meant to be played as a loading screen.
-    pub fn load_now_gif_from_bytes(
+    /// Use `included_bytes!` macro to load the bytes.
+    pub fn load_now_from_bytes_gif(
         bytes: &[u8],
         app: &mut App,
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
@@ -120,9 +121,10 @@ impl AnimatedImageLoader {
             .add(gif))
     }
 
-    /// For gif that need to be loaded immediately, during app setup.
-    /// This can be useful if the gif is meant to be played as a loading screen.
-    pub fn load_now_webp_from_bytes(
+    /// For webp that need to be loaded immediately, during app setup.
+    /// This can be useful if the webp is meant to be played as a loading screen.
+    /// Use `included_bytes!` macro to load the bytes.
+    pub fn load_now_from_bytes_webp(
         bytes: &[u8],
         app: &mut App,
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -108,7 +108,7 @@ impl AnimatedImageLoader {
     /// For gif that need to be loaded immediately, during app setup.
     /// This can be useful if the gif is meant to be played as a loading screen.
     /// Use `included_bytes!` macro to load the bytes.
-    pub fn load_now_from_bytes_gif(
+    pub fn load_now_gif_bytes(
         bytes: &[u8],
         app: &mut App,
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
@@ -124,7 +124,7 @@ impl AnimatedImageLoader {
     /// For webp that need to be loaded immediately, during app setup.
     /// This can be useful if the webp is meant to be played as a loading screen.
     /// Use `included_bytes!` macro to load the bytes.
-    pub fn load_now_from_bytes_webp(
+    pub fn load_now_webp_bytes(
         bytes: &[u8],
         app: &mut App,
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -113,6 +113,8 @@ impl AnimatedImageLoader {
     /// # use vleue_kinetoscope::AnimatedImageLoader;
     /// # let mut app = bevy::prelude::App::new();
     /// # app.add_plugins(bevy::prelude::AssetPlugin::default());
+    /// # app.init_asset::<bevy::prelude::Image>();
+    /// app.add_plugin(vleue_kinetoscope::AnimatedImagePlugin);
     /// let bytes = include_bytes!("../assets/cube.gif");
     /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", &mut app).unwrap();
     /// ```

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -105,32 +105,23 @@ impl AnimatedImageLoader {
             .add(gif))
     }
 
-    /// For gif that need to be loaded immediately, during app setup.
-    /// This can be useful if the gif is meant to be played as a loading screen.
+    /// For animated image that need to be loaded immediately, during app setup.
+    /// This can be useful if the video is meant to be played as a loading screen.
     /// Use `included_bytes!` macro to load the bytes.
-    pub fn load_now_gif_bytes(
+    /// # Example
+    /// ```
+    /// # let mut app = App::new();
+    /// let bytes = include_bytes!("../assets/foo.gif");
+    /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "gif", app).unwrap()
+    /// ```
+    pub fn load_now_from_bytes(
         bytes: &[u8],
+        extension: &str,
         app: &mut App,
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
         let mut images = app.world_mut().resource_mut::<Assets<Image>>();
         let bytes = bytes.to_vec();
-        let gif = Self::internal_load(bytes, &mut *images, Path::new("foo.gif"))?;
-        Ok(app
-            .world_mut()
-            .resource_mut::<Assets<AnimatedImage>>()
-            .add(gif))
-    }
-
-    /// For webp that need to be loaded immediately, during app setup.
-    /// This can be useful if the webp is meant to be played as a loading screen.
-    /// Use `included_bytes!` macro to load the bytes.
-    pub fn load_now_webp_bytes(
-        bytes: &[u8],
-        app: &mut App,
-    ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
-        let mut images = app.world_mut().resource_mut::<Assets<Image>>();
-        let bytes = bytes.to_vec();
-        let gif = Self::internal_load(bytes, &mut *images, Path::new("foo.webp"))?;
+        let gif = Self::internal_load(bytes, &mut *images, &Path::new("").with_extension(extension))?;
         Ok(app
             .world_mut()
             .resource_mut::<Assets<AnimatedImage>>()

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -113,7 +113,7 @@ impl AnimatedImageLoader {
     /// # use vleue_kinetoscope::AnimatedImageLoader;
     /// # let mut app = bevy::prelude::App::new();
     /// let bytes = include_bytes!("../assets/cube.gif");
-    /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", app).unwrap();
+    /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", &mut app).unwrap();
     /// ```
     pub fn load_now_from_bytes(
         bytes: &[u8],

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -104,6 +104,36 @@ impl AnimatedImageLoader {
             .resource_mut::<Assets<AnimatedImage>>()
             .add(gif))
     }
+
+    /// For gif that need to be loaded immediately, during app setup.
+    /// This can be useful if the gif is meant to be played as a loading screen.
+    pub fn load_now_gif_from_bytes(
+        bytes: &[u8],
+        app: &mut App,
+    ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
+        let mut images = app.world_mut().resource_mut::<Assets<Image>>();
+        let bytes = bytes.to_vec();
+        let gif = Self::internal_load(bytes, &mut *images, Path::new("foo.gif"))?;
+        Ok(app
+            .world_mut()
+            .resource_mut::<Assets<AnimatedImage>>()
+            .add(gif))
+    }
+
+    /// For gif that need to be loaded immediately, during app setup.
+    /// This can be useful if the gif is meant to be played as a loading screen.
+    pub fn load_now_webp_from_bytes(
+        bytes: &[u8],
+        app: &mut App,
+    ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
+        let mut images = app.world_mut().resource_mut::<Assets<Image>>();
+        let bytes = bytes.to_vec();
+        let gif = Self::internal_load(bytes, &mut *images, Path::new("foo.webp"))?;
+        Ok(app
+            .world_mut()
+            .resource_mut::<Assets<AnimatedImage>>()
+            .add(gif))
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -111,10 +111,11 @@ impl AnimatedImageLoader {
     /// # Example
     /// ```
     /// # use vleue_kinetoscope::AnimatedImageLoader;
+    /// # use bevy::prelude::AssetApp;
     /// # let mut app = bevy::prelude::App::new();
     /// # app.add_plugins(bevy::prelude::AssetPlugin::default());
     /// # app.init_asset::<bevy::prelude::Image>();
-    /// app.add_plugin(vleue_kinetoscope::AnimatedImagePlugin);
+    /// app.add_plugins(vleue_kinetoscope::AnimatedImagePlugin);
     /// let bytes = include_bytes!("../assets/cube.gif");
     /// let handle = AnimatedImageLoader::load_now_from_bytes(bytes, "cube.gif", &mut app).unwrap();
     /// ```

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -121,7 +121,7 @@ impl AnimatedImageLoader {
     ) -> Result<Handle<AnimatedImage>, AnimatedImageLoaderError> {
         let mut images = app.world_mut().resource_mut::<Assets<Image>>();
         let bytes = bytes.to_vec();
-        let gif = Self::internal_load(bytes, &mut *images, &Path::new("").with_extension(extension))?;
+        let gif = Self::internal_load(bytes, &mut *images, Path::new(&format!("foo.{extension}")))?;
         Ok(app
             .world_mut()
             .resource_mut::<Assets<AnimatedImage>>()


### PR DESCRIPTION
- Added `load_now_from_bytes` to load the file from raw bytes.

You can now use `include_bytes!()` macro to embedd files into the binary.