### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_kinetoscope"
-version = "0.4.0-rc.2"
+version = "0.4.0"
 edition = "2024"
 exclude = ["animated-gif.webp"]
 authors = ["François Mockers <francois.mockers@vleue.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_kinetoscope"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 edition = "2024"
 exclude = ["animated-gif.webp"]
 authors = ["François Mockers <francois.mockers@vleue.com>"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 |Bevy|vleue_kinetoscope|
 |---|---|
 |main|main|
+|0.16|0.4|
 |0.15|0.3|
 |0.14|0.2|
 |0.13|0.1|


### PR DESCRIPTION



## 🤖 New release

* `vleue_kinetoscope`: 0.4.0-rc.1 -> 0.4.0-rc.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).