### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_kinetoscope"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 exclude = ["animated-gif.webp", "assets/big-buck-bunny.webp"]
 authors = ["François Mockers <francois.mockers@vleue.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vleue_kinetoscope`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).